### PR TITLE
Update docs to reflect current Chrome version in supported-software.md

### DIFF
--- a/installation/supported-software.md
+++ b/installation/supported-software.md
@@ -4,4 +4,4 @@
 |----|----|----|----|----|----|----|
 | **0.4** | 0.12+ | 1.6+ | Chrome 30+, Firefox latest | SMSSync | N/A | N/A |
 | **2.x** | 6+ | 1.6+ | Chrome 30+, Firefox latest | medic-gateway | 4.4+ | Any |
-| **3.x** | 8.11+ | 2.1+ | Chrome 54+, Firefox latest | medic-gateway | 4.4+ | 0.4.5+ |
+| **3.x** | 8.11+ | 2.1+ | Chrome/53+, Firefox latest | medic-gateway | 4.4+ | 0.4.5+ |

--- a/installation/supported-software.md
+++ b/installation/supported-software.md
@@ -4,4 +4,4 @@
 |----|----|----|----|----|----|----|
 | **0.4** | 0.12+ | 1.6+ | Chrome 30+, Firefox latest | SMSSync | N/A | N/A |
 | **2.x** | 6+ | 1.6+ | Chrome 30+, Firefox latest | medic-gateway | 4.4+ | Any |
-| **3.x** | 8.11+ | 2.1+ | Chrome/53+, Firefox latest | medic-gateway | 4.4+ | 0.4.5+ |
+| **3.x** | 8.11+ | 2.1+ | Chrome 53+, Firefox latest | medic-gateway | 4.4+ | 0.4.5+ |


### PR DESCRIPTION
This is the most recent android app's user agent, reporting Chrome 53:

`Mozilla/5.0 (Linux; Android 5.1.1; SM-G361H Build/LMY48B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Crosswalk/23.53.589.4 Mobile Safari/537.36 org.medicmobile.webapp.mobile/SNAPSHOT`